### PR TITLE
fix for Bowler ISSUE-15 

### DIFF
--- a/src/main/scala/com/recursivity/commons/bean/scalap/ClassSignature.scala
+++ b/src/main/scala/com/recursivity/commons/bean/scalap/ClassSignature.scala
@@ -83,7 +83,7 @@ object ClassSignature extends RegexParsers {
 
   def parseDef(memberString: String): Member = {
     val returnTypeString = memberString.substring(memberString.lastIndexOf(":") + 2).trim
-    val functionString = memberString.substring(0, memberString.lastIndexOf(":") - 1).trim
+    val functionString = ReflectedName.unapply(memberString.substring(0, memberString.lastIndexOf(":") - 1).trim)
 
     val returnType : GenericTypeDefinition = parse(className, returnTypeString) match{
       case Success(definition, _) => GenericTypeDefinition(definition)
@@ -101,11 +101,28 @@ object ClassSignature extends RegexParsers {
 
 }
 
+object ReflectedName {
+  val tokens = List[Tuple2[String, String]](
+    (" ", "$u0020"),
+    ("/", "$div"),
+    (":", "$colon"),
+    ("*", "$times"),
+    ("=", "$eq"),
+    ("-", "$minus"),
+    ("+", "$plus"),
+    (">", "$greater"),
+    ("<", "$less"),
+    (".", "$u002E")
+  )
+
+  def apply(name: String) = tokens.foldLeft(name)((s, t) => s.replace(t._1, t._2))
+  def unapply(name: String) = tokens.foldLeft(name)((s, t) => s.replace(t._2, t._1))
+}
+
 case class ClassSignature(clazz: String, constructor: List[Parameter], members: List[Member])
 
 case class Member(defType: DefType, name: String, returnType: GenericTypeDefinition, parameters: List[Parameter]){
-  def reflectedName = name.replace(" ", "$u0020").replace("/","$div").replace(":","$colon").
-    replace("*","$times").replace("=","$eq").replace("-","$minus").replace("+","$plus").replace(">", "$greater").replace("<","$less").replace(".", "$u002E")
+  def reflectedName = ReflectedName(name)
 }
 case class Parameter(name: String, paramType: GenericTypeDefinition)
 

--- a/src/test/scala/com/recursivity/commons/bean/scalap/ClassSignatureTest.scala
+++ b/src/test/scala/com/recursivity/commons/bean/scalap/ClassSignatureTest.scala
@@ -132,7 +132,9 @@ class ClassSignatureTest extends FunSuite{
     val sig = ClassSignature(obj.getClass)
     assert(sig.members.find(p => p.name == "hello") != None)
     assert(sig.members.find(p => p.name == "world") != None)
-
+    val put = "PUT$u0020$divhello$divmyworld"
+    val putFunc = sig.members.find(p => p.name.startsWith("PUT"))
+    assert(put == putFunc.get.reflectedName)
   }
 
 }
@@ -153,6 +155,7 @@ case class GenerifiedClass(hello: List[String])
 
 trait MyParentTrait{
   def hello = "Hello"
+  def `PUT /hello/myworld` = "world"
 }
 
 class ChildClass{


### PR DESCRIPTION
- Added test with funky name in weaved in trait
- Handling of reflected name when parsing def
