### PR TITLE
fix: make sure complete class file is read from stream into buffer

### DIFF
--- a/src/main/scala/com/recursivity/commons/bean/scalap/ScalaSigParser.scala
+++ b/src/main/scala/com/recursivity/commons/bean/scalap/ScalaSigParser.scala
@@ -48,10 +48,9 @@ object ScalaSigParser {
       else classname)
     val name = "/" + encName.replace(".", "/") + ".class"
     val resource = this.getClass.getResourceAsStream(name)
-    val bytes = new Array[Byte](resource.available)
-    resource.read(bytes)
 
-    //val bytes = null//cfile.toByteArray
+    val bytes = readToBytes(resource)
+
     if (isScalaFile(bytes)) {
       return decompileScala(bytes, isPackageObjectFile(classname))
     } else {
@@ -61,6 +60,17 @@ object ScalaSigParser {
       val clazz = new Classfile(reader)
       return processJavaClassFile(clazz)
     }
+  }
+
+  def readToBytes(stream: java.io.InputStream): Array[Byte] = {
+    val len = stream.available
+    val bytes = new Array[Byte](len)
+
+    var cur = 0
+    while (cur != -1)
+      cur += stream.read(bytes, cur, len - cur)
+
+    bytes
   }
 
   def isPackageObjectFile(s: String) = s != null && (s.endsWith(".package") || s == "package")


### PR DESCRIPTION
We are getting those errors while using bowler:

```
[info]   scala.tools.scalap.scalax.rules.ScalaSigParserError: Unexpected failure
[info]   at scala.tools.scalap.scalax.rules.Rules$$anonfun$expect$1.apply(Rules.scala:68)
[info]   at scala.tools.scalap.scalax.rules.scalasig.ClassFileParser$.parse(ClassFileParser.scala:96)
[info]   at com.recursivity.commons.bean.scalap.ScalaSigParser$.isScalaFile(ScalaSigParser.scala:86)
[info]   at com.recursivity.commons.bean.scalap.ScalaSigParser$.process(ScalaSigParser.scala:59)
[info]   at com.recursivity.commons.bean.scalap.ClassSignature$.apply(ClassSignature.scala:49)
[info]   at com.recursivity.commons.bean.scalap.ClassSignature$.apply(ClassSignature.scala:62)
[info]   at com.recursivity.commons.bean.scalap.ClassSignature$.apply(ClassSignature.scala:45)
[info]   at org.bowlerframework.controller.POSORouteMapper$.apply(POSORouteMapper.scala:21)
[info]   at org.bowlerframework.controller.FunctionNameConventionRoutes$class.$init$(FunctionNameConventionRoutes.scala:14)
```

That's because the code isn't checking properly if the complete class file has been read into the buffer before parsing the file. Here's a fix which implements this fix. How fast could you publish an updated version?
