### PR TITLE
a minor fix so TransformerRegistry understands scala Doubles

### DIFF
--- a/src/main/scala/com/recursivity/commons/bean/BeanUtils.scala
+++ b/src/main/scala/com/recursivity/commons/bean/BeanUtils.scala
@@ -109,7 +109,7 @@ object BeanUtils {
     result
   }
 
-  private def resolveGenerifiedValue(cls: Class[_], genericType: GenericTypeDefinition, input: Any): Any = {
+  def resolveGenerifiedValue(cls: Class[_], genericType: GenericTypeDefinition, input: Any): Any = {
     if (classOf[TraversableLike[_ <: Any, _ <: Any]].isAssignableFrom(cls)) {
       val list = valueList(genericType, input)
       return resolveTraversableOrArray(cls, list)
@@ -131,7 +131,7 @@ object BeanUtils {
     }
   }
 
-  def resolveJavaCollectionType(cls: Class[_], list: MutableList[_]): Any = {
+  def resolveJavaCollectionType(cls: Class[_], list: scala.collection.Seq[_]): Any = {
     if(classOf[java.util.Set[_]].isAssignableFrom(cls)){
       var set: java.util.Set[Any] = null
       try{
@@ -153,7 +153,7 @@ object BeanUtils {
     }
   }
 
-  private def valueList(genericType: GenericTypeDefinition, input: Any): MutableList[Any] = {
+  def valueList(genericType: GenericTypeDefinition, input: Any): MutableList[Any] = {
     val c = genericType.genericTypes.get.head.definedClass
     val transformer = TransformerRegistry(c)
     val list = new MutableList[Any]
@@ -170,7 +170,7 @@ object BeanUtils {
   // due to the trickiness of supporting immutable sets/lists, types are hard coded here with no support for extension
   // of immutable Scala Sets/Lists, TreeSet is not supported
   //
-  def resolveTraversableOrArray(cls: Class[_], list: MutableList[_]): Any = {
+  def resolveTraversableOrArray(cls: Class[_], list: scala.collection.Seq[_]): Any = {
     if (cls.equals(classOf[List[_]])) {
       return list.toList
     } else if (cls.equals(classOf[Set[_]]))

--- a/src/main/scala/com/recursivity/commons/bean/ScalaDoubleTransformer.scala
+++ b/src/main/scala/com/recursivity/commons/bean/ScalaDoubleTransformer.scala
@@ -1,0 +1,20 @@
+package com.recursivity.commons.bean
+
+/**
+ * Created by IntelliJ IDEA.
+ * User: wfaler
+ * Date: Apr 19, 2010
+ * Time: 8:17:09 PM
+ * To change this template use File | Settings | File Templates.
+ */
+
+class ScalaDoubleTransformer extends StringValueTransformer[Double]{
+  def toValue(from: String): Option[Double] = {
+    try{
+      return Some(from.toDouble)
+    }catch{
+      case e: Exception => return None
+    }
+  }
+
+}

--- a/src/main/scala/com/recursivity/commons/bean/TransformerRegistry.scala
+++ b/src/main/scala/com/recursivity/commons/bean/TransformerRegistry.scala
@@ -12,6 +12,7 @@ object TransformerRegistry{
   registry += classOf[Boolean] -> classOf[JavaBooleanTransformer]
   registry += classOf[java.util.Date] -> classOf[DateTransformer]
   registry += classOf[Int] -> classOf[JavaIntegerTransformer]
+  registry += classOf[Double] -> classOf[ScalaDoubleTransformer]
   registry += classOf[java.math.BigDecimal] -> classOf[JavaBigDecimalTransformer]
   registry += classOf[java.lang.Boolean] -> classOf[JavaBooleanTransformer]
   registry += classOf[java.lang.Integer] -> classOf[JavaIntegerTransformer]


### PR DESCRIPTION
i.e. scala.Double as opposed to java.lang.Double
