### PR TITLE
Fixing the scalap problem in the build.

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -2,7 +2,7 @@
 #Sat Apr 30 19:45:58 BST 2011
 project.organization=com.recursivity
 project.name=recursivity-commons
-sbt.version=0.7.5.RC0
+sbt.version=0.7.7
 project.version=0.6
 build.scala.versions=2.9.1
 project.initialize=false

--- a/project/build/CommonsProject.scala
+++ b/project/build/CommonsProject.scala
@@ -10,7 +10,7 @@ class CommonsProject(info: ProjectInfo) extends DefaultProject(info){//} with Ch
   }
 
   val asm = "org.scala-lang" % "scalap" % buildScalaVersion
-	
+
   Credentials(Path.userHome / ".ivy2" / ".credentials", log)
 
   val publishTo = {
@@ -27,6 +27,7 @@ class CommonsProject(info: ProjectInfo) extends DefaultProject(info){//} with Ch
   lazy val sourceArtifact = Artifact.sources(artifactID)
   lazy val docsArtifact = Artifact.javadoc(artifactID)
   val scalaTestRepo = "Scala Test Repo" at "http://scala-tools.org/repo-snapshots"
+  val typesafeRepo = "Typesafe Repo" at "http://repo.typesafe.com/typesafe/releases"
 
   override def packageToPublishActions = super.packageToPublishActions ++ Seq(packageDocs, packageSrc)
   override def pomExtra = {


### PR DESCRIPTION
I've updated to sbt 0.7.7, so that the latest versions of sbt (0.11.3, certainly) can successfully drop back, and adding the typesafe repository that holds scalap artifacts. "sbt update" now works!
